### PR TITLE
change prettier to match dprint settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,8 @@
     "testEnvironment": "node"
   },
   "prettier": {
-    "printWidth": 999
+    "printWidth": 999,
+    "singleQuote": true,
+    "tabWidth": 4
   }
 }


### PR DESCRIPTION
Prettier was incorrectly formatting due to `package.json` not specifying the same rules that `dprint.json` is using.