### PR TITLE
Add an env var for the backend port.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,4 +14,7 @@ DATABASE_PASSWORD=admin
 DISCORD_CLIENT_ID=1234567890
 DISCORD_CLIENT_SECRET="secret"
 
+# the frontend is expected to be listening at the following URL:
 WEB_APP_URL=http://localhost:5173
+# the backend will listen on the following port:
+BACKEND_PORT=3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,8 @@ services:
       - .:/app
     # Expose the development server port (if needed)
     ports:
-      - '3000:3000'
+        # use the BACKEND_PORT variable from .env or 3000 by default
+      - '${BACKEND_PORT:-3000}:${BACKEND_PORT:-3000}'
     # Install and run the development server using Yarn
     command:
       - sh

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,9 @@ async function bootstrap() {
         credentials: true,
     };
     app.enableCors(corsOptions);
-    await app.listen(3000);
+
+    const backendPort = configService.get<number>('BACKEND_PORT', 3000);
+    await app.listen(backendPort);
 }
 
 bootstrap();


### PR DESCRIPTION
The backend will listen on the port specified in the BACKEND_PORT variable set in .env or 3000 by default.